### PR TITLE
ci: `diff_types` should send all. Deprecate `diff_types`

### DIFF
--- a/app/pkg/pr.go
+++ b/app/pkg/pr.go
@@ -38,6 +38,9 @@ func (p *PR) Get(req *PRRequest, types []models.Type) (string, error) {
 	commitBaseBranch := ""
 	isFirstPR := p.coverageModel.IsFirstPR(req.Org, req.Repo, req.PRNum)
 
+	isFirstPR = true // always since comments are updated
+	req.DiffTypes = "" //always, diff_types is deprecated and will be abolished
+
 	mdText := md.NewMarkdown(os.Stdout)
 	mdTable := md.TableSet{
 		Rows: [][]string{},


### PR DESCRIPTION
Related to #29 & #25 

#25 since now there will be just one comment, which will keep on editing, there is no reason to keep this confusing `diff_types`
Just `types:` if you want a comment for that type or not.
empty will be all types in principle

`diff_types` was for 2 comment and onwards to only report those types. Anyways, さよなら